### PR TITLE
refactor: remove unused nodemon import

### DIFF
--- a/server/middleware/tokenValidation.js
+++ b/server/middleware/tokenValidation.js
@@ -1,5 +1,4 @@
 const jwt = require('jsonwebtoken')
-const { restart } = require('nodemon')
 
 module.exports.validateToken = (req, res, next) => {
   let response = {}


### PR DESCRIPTION
## Summary
- remove unused `nodemon` import from tokenValidation middleware

## Testing
- `grep -n restart -R server/middleware/tokenValidation.js`


------
https://chatgpt.com/codex/tasks/task_b_68838ff516b483318a5d11c3f337a198