### PR TITLE
feat: store decoded JWT on request

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ Static HTML and CSS has been created for most of the site and is located in: `/d
 For some of the dynamic features, like toggling user editing, there is a mock-up for it in `/designs/wireframes/edit-user-name.png`.
 
 And for the API model that you will be proposing for transactitons, the wireframe can be found in `/designs/wireframes/transactions.png`.
+
+## Manual Testing
+
+Follow these steps to verify that authenticated routes work correctly:
+
+1. Start the server with `npm run dev:server` and make sure the database is populated using `npm run populate-db`.
+2. Send a `POST` request to `/api/v1/user/login` with one of the sample user credentials to obtain a JWT token.
+3. Use the returned token in the `Authorization` header (e.g. `Bearer YOUR_TOKEN`) and call `/api/v1/user/profile`.
+   You should receive the user profile data as the response.
+4. You can also update the user profile by sending a `PUT` request to `/api/v1/user/profile` with the token and the updated fields.

--- a/server/middleware/tokenValidation.js
+++ b/server/middleware/tokenValidation.js
@@ -14,6 +14,7 @@ module.exports.validateToken = (req, res, next) => {
       userToken,
       process.env.SECRET_KEY || 'default-secret-key'
     )
+    req.user = decodedToken
     return next()
   } catch (error) {
     console.error('Error in tokenValidation.js', error)

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -29,9 +29,7 @@ module.exports.createUser = async serviceData => {
 
 module.exports.getUserProfile = async serviceData => {
   try {
-    const jwtToken = serviceData.headers.authorization.split('Bearer')[1].trim()
-    const decodedJwtToken = jwt.decode(jwtToken)
-    const user = await User.findOne({ _id: decodedJwtToken.id })
+    const user = await User.findOne({ _id: serviceData.user.id })
 
     if (!user) {
       throw new Error('User not found!')
@@ -73,10 +71,8 @@ module.exports.loginUser = async serviceData => {
 
 module.exports.updateUserProfile = async serviceData => {
   try {
-    const jwtToken = serviceData.headers.authorization.split('Bearer')[1].trim()
-    const decodedJwtToken = jwt.decode(jwtToken)
     const user = await User.findOneAndUpdate(
-      { _id: decodedJwtToken.id },
+      { _id: serviceData.user.id },
       {
         firstName: serviceData.body.firstName,
         lastName: serviceData.body.lastName


### PR DESCRIPTION
## Summary
- attach decoded JWT to `req.user` in token validation middleware
- use `req.user` in user service methods
- document manual steps for testing auth routes

## Testing
- `npm run --silent server` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68838f178a38833195038660f41119fe