### PR TITLE
Add user route tests with jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,13 @@
   "scripts": {
     "dev:server": "nodemon ./server/server.js",
     "populate-db": "node ./server/scripts/populateDatabase.js",
-    "server": "node ./server/server.js"
+    "server": "node ./server/server.js",
+    "test": "jest --runInBand"
   },
   "devDependencies": {
-    "nodemon": "^2.0.4"
+    "nodemon": "^2.0.4",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "mongodb-memory-server": "^9.8.0"
   }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -33,6 +33,10 @@ app.get('/', (req, res, next) => {
   res.send('Hello from my Express server v2!')
 })
 
-app.listen(PORT, () => {
-  console.log(`Server listening on http://localhost:${PORT}`)
-})
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Server listening on http://localhost:${PORT}`)
+  })
+}
+
+module.exports = app

--- a/server/tests/userRoutes.test.js
+++ b/server/tests/userRoutes.test.js
@@ -1,0 +1,88 @@
+const request = require('supertest')
+const mongoose = require('mongoose')
+const { MongoMemoryServer } = require('mongodb-memory-server')
+
+let app
+let mongoServer
+let token
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create()
+  process.env.DATABASE_URL = mongoServer.getUri()
+  process.env.SECRET_KEY = 'testsecret'
+  process.env.NODE_ENV = 'test'
+  app = require('../server')
+  await require('../database/connection')()
+
+  await request(app).post('/api/v1/user/signup').send({
+    firstName: 'Test',
+    lastName: 'User',
+    email: 'test@example.com',
+    password: 'pass123'
+  })
+})
+
+afterAll(async () => {
+  await mongoose.disconnect()
+  await mongoServer.stop()
+})
+
+describe('User routes', () => {
+  test('login returns a token', async () => {
+    const res = await request(app)
+      .post('/api/v1/user/login')
+      .send({ email: 'test@example.com', password: 'pass123' })
+      .expect(200)
+    expect(res.body.body.token).toBeDefined()
+    token = res.body.body.token
+  })
+
+  test('get profile with valid token', async () => {
+    const res = await request(app)
+      .post('/api/v1/user/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+    expect(res.body.body.email).toBe('test@example.com')
+  })
+
+  test('update profile with valid token', async () => {
+    const res = await request(app)
+      .put('/api/v1/user/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ firstName: 'New', lastName: 'Name' })
+      .expect(200)
+    expect(res.body.body.firstName).toBe('New')
+  })
+
+  test('profile request missing token', async () => {
+    const res = await request(app)
+      .post('/api/v1/user/profile')
+      .expect(401)
+    expect(res.body.message).toMatch(/Token is missing/)
+  })
+
+  test('profile request invalid token', async () => {
+    const res = await request(app)
+      .post('/api/v1/user/profile')
+      .set('Authorization', 'Bearer invalidtoken')
+      .expect(401)
+    expect(res.body.message).toBeDefined()
+  })
+
+  test('update profile missing token', async () => {
+    const res = await request(app)
+      .put('/api/v1/user/profile')
+      .send({ firstName: 'A', lastName: 'B' })
+      .expect(401)
+    expect(res.body.message).toMatch(/Token is missing/)
+  })
+
+  test('update profile invalid token', async () => {
+    const res = await request(app)
+      .put('/api/v1/user/profile')
+      .set('Authorization', 'Bearer badtoken')
+      .send({ firstName: 'A', lastName: 'B' })
+      .expect(401)
+    expect(res.body.message).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add jest, supertest and mongodb-memory-server dev dependencies
- expose Express app in server
- add integration tests for login and profile routes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_688395f39e008331bb7e8f903d9e980a