### PR TITLE
Improve token validation

### DIFF
--- a/server/middleware/tokenValidation.js
+++ b/server/middleware/tokenValidation.js
@@ -4,11 +4,25 @@ module.exports.validateToken = (req, res, next) => {
   let response = {}
 
   try {
-    if (!req.headers.authorization) {
-      throw new Error('Token is missing from header')
+    const authHeader = req.headers.authorization
+    if (!authHeader) {
+      throw new Error('Authorization header missing')
     }
 
-    const userToken = req.headers.authorization.split('Bearer')[1].trim()
+    if (!authHeader.startsWith('Bearer ')) {
+      throw new Error('Authorization header must start with "Bearer "')
+    }
+
+    const tokenParts = authHeader.split('Bearer ')
+    if (!tokenParts[1]) {
+      throw new Error('Token not provided')
+    }
+
+    const userToken = tokenParts[1].trim()
+    if (!userToken) {
+      throw new Error('Token not provided')
+    }
+
     const decodedToken = jwt.verify(
       userToken,
       process.env.SECRET_KEY || 'default-secret-key'


### PR DESCRIPTION
## Summary
- handle Bearer header format
- provide clearer 401 errors on auth header issues

## Testing
- `node -c server/middleware/tokenValidation.js`
- `node server/server.js` *(fails: Cannot find module 'express')*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_688395f1c4588331a93755eb487a8c5a