### PR TITLE
Require SECRET_KEY

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 DATABASE_URL="mongodb://localhost/argentBankDB"
+SECRET_KEY="your-secret-key"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ mongo --version
 1. Fork this repo
 1. Clone the repo onto your computer
 1. Open a terminal window in the cloned project
+1. Edit the `.env` file and set a value for `SECRET_KEY`
 1. Run the following commands:
 
 ```bash

--- a/server/middleware/tokenValidation.js
+++ b/server/middleware/tokenValidation.js
@@ -9,10 +9,7 @@ module.exports.validateToken = (req, res, next) => {
     }
 
     const userToken = req.headers.authorization.split('Bearer')[1].trim()
-    const decodedToken = jwt.verify(
-      userToken,
-      process.env.SECRET_KEY || 'default-secret-key'
-    )
+    const decodedToken = jwt.verify(userToken, process.env.SECRET_KEY)
     req.user = decodedToken
     return next()
   } catch (error) {

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -56,11 +56,9 @@ module.exports.loginUser = async serviceData => {
       throw new Error('Password is invalid')
     }
 
-    const token = jwt.sign(
-      { id: user._id },
-      process.env.SECRET_KEY || 'default-secret-key',
-      { expiresIn: '1d' }
-    )
+    const token = jwt.sign({ id: user._id }, process.env.SECRET_KEY, {
+      expiresIn: '1d'
+    })
 
     return { token }
   } catch (error) {


### PR DESCRIPTION
## Summary
- remove fallback SECRET_KEY usages
- add SECRET_KEY in `.env`
- document SECRET_KEY setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_688395f165f88331a92a7fd245b2eddd