### PR TITLE
Standardize token error message

### DIFF
--- a/server/middleware/tokenValidation.js
+++ b/server/middleware/tokenValidation.js
@@ -6,21 +6,21 @@ module.exports.validateToken = (req, res, next) => {
   try {
     const authHeader = req.headers.authorization
     if (!authHeader) {
-      throw new Error('Authorization header missing')
+      throw new Error('Token is missing')
     }
 
     if (!authHeader.startsWith('Bearer ')) {
-      throw new Error('Authorization header must start with "Bearer "')
+      throw new Error('Token is missing')
     }
 
     const tokenParts = authHeader.split('Bearer ')
     if (!tokenParts[1]) {
-      throw new Error('Token not provided')
+      throw new Error('Token is missing')
     }
 
     const userToken = tokenParts[1].trim()
     if (!userToken) {
-      throw new Error('Token not provided')
+      throw new Error('Token is missing')
     }
 
     const decodedToken = jwt.verify(
@@ -32,7 +32,7 @@ module.exports.validateToken = (req, res, next) => {
   } catch (error) {
     console.error('Error in tokenValidation.js', error)
     response.status = 401
-    response.message = error.message
+    response.message = 'Token is missing'
   }
 
   return res.status(response.status).send(response)

--- a/server/tests/userRoutes.test.js
+++ b/server/tests/userRoutes.test.js
@@ -66,7 +66,7 @@ describe('User routes', () => {
       .post('/api/v1/user/profile')
       .set('Authorization', 'Bearer invalidtoken')
       .expect(401)
-    expect(res.body.message).toBeDefined()
+    expect(res.body.message).toMatch(/Token is missing/)
   })
 
   test('update profile missing token', async () => {
@@ -83,6 +83,6 @@ describe('User routes', () => {
       .set('Authorization', 'Bearer badtoken')
       .send({ firstName: 'A', lastName: 'B' })
       .expect(401)
-    expect(res.body.message).toBeDefined()
+    expect(res.body.message).toMatch(/Token is missing/)
   })
 })


### PR DESCRIPTION
## Summary
- unify token validation errors on backend
- adjust tests to expect standardized message

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883af891ba88331bc2e2e71cc34f4a3