### PR TITLE
Add env example and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="mongodb://localhost/argentBankDB"
+SECRET_KEY="changeme"
+PORT=3001

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ mongo --version
 1. Fork this repo
 1. Clone the repo onto your computer
 1. Open a terminal window in the cloned project
+1. Copy `.env.example` to `.env` and update the values if needed
 1. Run the following commands:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `.env.example` with default values
- document copying `.env.example` during setup

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6883af8b1b9c83319dd9fb8d265a2553