### PR TITLE
Fix login fail status

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -27,7 +27,7 @@ module.exports.loginUser = async (req, res) => {
     response.body = responseFromService
   } catch (error) {
     console.error('Error in loginUser (userController.js)')
-    response.status = 400
+    response.status = 401
     response.message = error.message
   }
 

--- a/server/tests/userRoutes.test.js
+++ b/server/tests/userRoutes.test.js
@@ -37,6 +37,20 @@ describe('User routes', () => {
     token = res.body.body.token
   })
 
+  test('login with wrong password fails', async () => {
+    await request(app)
+      .post('/api/v1/user/login')
+      .send({ email: 'test@example.com', password: 'wrongpass' })
+      .expect(401)
+  })
+
+  test('login with unknown email fails', async () => {
+    await request(app)
+      .post('/api/v1/user/login')
+      .send({ email: 'nouser@example.com', password: 'pass123' })
+      .expect(401)
+  })
+
   test('get profile with valid token', async () => {
     const res = await request(app)
       .post('/api/v1/user/profile')


### PR DESCRIPTION
## Summary
- return HTTP 401 from `loginUser` when credentials are invalid
- add Jest tests covering failed logins

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883af8af1a88331b42338e24b7224b9