### PR TITLE
refactor: await db connection before server start

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,8 +11,17 @@ dotEnv.config()
 const app = express()
 const PORT = process.env.PORT || 3001
 
-// Connect to the database
-dbConnection()
+const startServer = async () => {
+  try {
+    await dbConnection()
+    app.listen(PORT, () => {
+      console.log(`Server listening on http://localhost:${PORT}`)
+    })
+  } catch (error) {
+    console.error('Failed to connect to the database', error)
+    process.exit(1)
+  }
+}
 
 // Handle CORS issues
 app.use(cors())
@@ -34,9 +43,7 @@ app.get('/', (req, res, next) => {
 })
 
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(PORT, () => {
-    console.log(`Server listening on http://localhost:${PORT}`)
-  })
+  startServer()
 }
-
 module.exports = app
+module.exports.startServer = startServer

--- a/server/tests/serverStart.test.js
+++ b/server/tests/serverStart.test.js
@@ -1,0 +1,39 @@
+process.env.NODE_ENV = 'test'
+
+jest.mock('../database/connection')
+const dbConnection = require('../database/connection')
+const app = require('../server')
+
+describe('Server startup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('starts server after successful DB connection', async () => {
+    dbConnection.mockResolvedValue()
+    const listenMock = jest.spyOn(app, 'listen').mockImplementation((port, cb) => cb && cb())
+
+    await app.startServer()
+
+    expect(dbConnection).toHaveBeenCalled()
+    expect(listenMock).toHaveBeenCalled()
+  })
+
+  test('does not start server if DB connection fails', async () => {
+    const error = new Error('db fail')
+    dbConnection.mockRejectedValue(error)
+    const listenMock = jest.spyOn(app, 'listen').mockImplementation(() => {})
+    const exitMock = jest.spyOn(process, 'exit').mockImplementation(() => {})
+    const errorMock = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await app.startServer()
+
+    expect(dbConnection).toHaveBeenCalled()
+    expect(listenMock).not.toHaveBeenCalled()
+    expect(exitMock).toHaveBeenCalledWith(1)
+    expect(errorMock).toHaveBeenCalled()
+
+    exitMock.mockRestore()
+    errorMock.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- only start Express server once database connection succeeds
- add tests for server startup and database connection failure

## Testing
- `npm install` *(fails: Failed to execute '/root/.nvm/...node-gyp.js configure --fallback-to-build --module=/workspace/Project-10-Bank-API-tom/node_modules/bcrypt/lib/binding/napi-v3/bcrypt_lib.node --module_name=bcrypt_lib --module_path=/workspace/Project-10-Bank-API-tom/node_modules/bcrypt/lib/binding/napi-v3 --napi_version=9 --node_abi_napi=napi --napi_build_version=3 --node_napi_label=napi-v3' (1))*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6892535a1d488331994b413b6cf50a39