### PR TITLE
docs: add database setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ node --version
 mongo --version
 ```
 
+### Database Setup
+
+You need a running MongoDB instance before starting the server. You can either:
+
+1. **Install MongoDB** by following the [MongoDB Community Server installation guide](https://www.mongodb.com/try/download/community).
+2. **Run MongoDB with Docker:**
+
+   ```bash
+   docker run -p 27017:27017 mongo
+   ```
+
+By default, the server expects the database at `mongodb://localhost/argentBankDB`. You can override this by setting the `DATABASE_URL` environment variable.
+
 ### Instructions
 
 1. Fork this repo


### PR DESCRIPTION
## Summary
- document how to start MongoDB locally or via Docker
- note default database URL for the server

## Testing
- `npm install` *(fails: unable to download Node.js headers for bcrypt build)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893035d186c8331806a24c6f3f881fa