### PR TITLE
Simplify routing to HomePage with fallback handler

### DIFF
--- a/frontendClean/src/App.jsx
+++ b/frontendClean/src/App.jsx
@@ -1,19 +1,12 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
-import Sidebar from './components/Sidebar.js';
-import UserProfile from './components/UserProfile.js';
-import NotFound from './components/NotFound.js';
+import { Routes, Route } from 'react-router-dom';
+import HomePage from './components/HomePage.jsx';
+import NotFound from './components/NotFound.jsx';
 
 export default function App() {
   return (
-    <div>
-      <Sidebar />
-      <div>
-        <Routes>
-          <Route path="/" element={<Navigate to="/user/12" replace />} />
-          <Route path="/user/:id" element={<UserProfile />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </div>
-    </div>
+    <Routes>
+      <Route path="/" element={<HomePage />} />
+      <Route path="*" element={<NotFound />} />
+    </Routes>
   );
 }

--- a/frontendClean/src/components/NotFound.jsx
+++ b/frontendClean/src/components/NotFound.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function NotFound() {
+    return (
+        <div>
+            <h1>404 - Page Not Found</h1>
+        </div>
+    );
+}
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- remove unused Sidebar and UserProfile routes in `App.jsx`
- add `HomePage` root route and new `NotFound` fallback component

## Testing
- `npm run lint` *(fails: 'WrappedComponent' is defined but never used)*
- `npm test` *(fails: jest not found; npm install fails to build bcrypt)*

------
https://chatgpt.com/codex/tasks/task_b_68937a6bd5cc8331bab37b7813df7801