### PR TITLE
feat: add redux store and auth provider

### DIFF
--- a/frontendClean/package.json
+++ b/frontendClean/package.json
@@ -14,8 +14,9 @@
     "react-dom": "^19.1.0",
     "axios": "^1.6.7",
     "recharts": "^2.8.0",
-    "react-router-dom": "^6.23.0"
-
+    "react-router-dom": "^6.23.0",
+    "@reduxjs/toolkit": "^2.2.1",
+    "react-redux": "^9.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/frontendClean/src/components/withAuth.jsx
+++ b/frontendClean/src/components/withAuth.jsx
@@ -10,15 +10,14 @@ import { Navigate } from 'react-router-dom';
  *   const ProtectedPage = withAuth(MyComponent);
  */
 const withAuth = (WrappedComponent) => {
-  const RequiresAuth = (props) => {
-    const token = useSelector((state) => state.auth && state.auth.token);
+  const Component = WrappedComponent;
+  return (props) => {
+    const token = useSelector((state) => state.auth.token);
     if (!token) {
       return <Navigate to="/login" replace />;
     }
-    return <WrappedComponent {...props} />;
+    return <Component {...props} />;
   };
-
-  return RequiresAuth;
 };
 
 export default withAuth;

--- a/frontendClean/src/main.jsx
+++ b/frontendClean/src/main.jsx
@@ -1,13 +1,17 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import store from './store';
+import './index.css';
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </StrictMode>,
-)
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
+  </StrictMode>
+);

--- a/frontendClean/src/store/index.js
+++ b/frontendClean/src/store/index.js
@@ -1,0 +1,26 @@
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: {
+    token: null,
+  },
+  reducers: {
+    setToken: (state, action) => {
+      state.token = action.payload;
+    },
+    clearToken: (state) => {
+      state.token = null;
+    },
+  },
+});
+
+export const { setToken, clearToken } = authSlice.actions;
+
+const store = configureStore({
+  reducer: {
+    auth: authSlice.reducer,
+  },
+});
+
+export default store;


### PR DESCRIPTION
## Summary
- add auth slice with token and configure Redux store
- wrap application with Redux Provider
- update withAuth to read auth token from store
- declare redux dependencies in frontend package

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: could not download bcrypt binaries)*

------
https://chatgpt.com/codex/tasks/task_b_68937a6cb390833185f5b200ab726c23