### PR TITLE
Add login page with API authentication

### DIFF
--- a/frontendClean/src/App.jsx
+++ b/frontendClean/src/App.jsx
@@ -1,11 +1,13 @@
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage.jsx';
 import NotFound from './components/NotFound.jsx';
+import LoginPage from './components/LoginPage.jsx';
 
 export default function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/login" element={<LoginPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/frontendClean/src/components/LoginPage.jsx
+++ b/frontendClean/src/components/LoginPage.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import MainNav from './MainNav';
+import Footer from './Footer';
+import { useDispatch } from 'react-redux';
+import { setToken } from '../store';
+import '../style/main.css';
+
+function LoginPage() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const dispatch = useDispatch();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            const response = await fetch('http://localhost:3001/api/v1/user/login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email, password }),
+            });
+            const data = await response.json();
+            if (response.ok && data.body && data.body.token) {
+                dispatch(setToken(data.body.token));
+            } else {
+                console.error('Login failed');
+            }
+        } catch (error) {
+            console.error('Error during login', error);
+        }
+    };
+
+    return (
+        <>
+            <MainNav />
+            <main className="main bg-dark">
+                <section className="sign-in-content">
+                    <i className="fa fa-user-circle sign-in-icon"></i>
+                    <h1>Sign In</h1>
+                    <form onSubmit={handleSubmit}>
+                        <div className="input-wrapper">
+                            <label htmlFor="username">Username</label>
+                            <input
+                                type="text"
+                                id="username"
+                                value={email}
+                                onChange={(e) => setEmail(e.target.value)}
+                            />
+                        </div>
+                        <div className="input-wrapper">
+                            <label htmlFor="password">Password</label>
+                            <input
+                                type="password"
+                                id="password"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                            />
+                        </div>
+                        <div className="input-remember">
+                            <input type="checkbox" id="remember-me" />
+                            <label htmlFor="remember-me">Remember me</label>
+                        </div>
+                        <button type="submit" className="sign-in-button">Sign In</button>
+                    </form>
+                </section>
+            </main>
+            <Footer />
+        </>
+    );
+}
+
+export default LoginPage;


### PR DESCRIPTION
## Summary
- Implement sign-in page matching design and posting credentials to backend
- Store returned auth token in Redux and add routing for `/login`

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found after dependency install failed, bcrypt build error)*

------
https://chatgpt.com/codex/tasks/task_b_6893802322948331bc679540b7d615b5