### PR TITLE
feat: add protected user page

### DIFF
--- a/frontendClean/src/App.jsx
+++ b/frontendClean/src/App.jsx
@@ -1,11 +1,13 @@
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage.jsx';
 import NotFound from './components/NotFound.jsx';
+import UserPage from './components/UserPage.jsx';
 
 export default function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/user" element={<UserPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/frontendClean/src/components/UserPage.jsx
+++ b/frontendClean/src/components/UserPage.jsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import MainNav from '../components/MainNav';
+import Footer from '../components/Footer';
+import withAuth from '../components/withAuth';
+
+function UserPage() {
+    const token = useSelector((state) => state.auth.token);
+    const [profile, setProfile] = useState({ firstName: '', lastName: '' });
+    const [editing, setEditing] = useState(false);
+    const [firstName, setFirstName] = useState('');
+    const [lastName, setLastName] = useState('');
+
+    useEffect(() => {
+        if (!token) {
+            return;
+        }
+        fetch('/profile', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+        })
+            .then((res) => res.json())
+            .then((data) => {
+                if (data && data.body) {
+                    setProfile({
+                        firstName: data.body.firstName,
+                        lastName: data.body.lastName,
+                    });
+                    setFirstName(data.body.firstName);
+                    setLastName(data.body.lastName);
+                }
+            })
+            .catch((err) => console.error('Failed to fetch profile', err));
+    }, [token]);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        fetch('/profile', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ firstName, lastName }),
+        })
+            .then((res) => res.json())
+            .then(() => {
+                setProfile({ firstName, lastName });
+                setEditing(false);
+            })
+            .catch((err) => console.error('Failed to update profile', err));
+    };
+
+    return (
+        <>
+            <MainNav />
+            <main className="main bg-dark">
+                <div className="header">
+                    {editing ? (
+                        <form className="edit-name-form" onSubmit={handleSubmit}>
+                            <div className="input-wrapper">
+                                <input type="text" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+                            </div>
+                            <div className="input-wrapper">
+                                <input type="text" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+                            </div>
+                            <button type="submit" className="save-button">Save</button>
+                            <button type="button" className="cancel-button" onClick={() => setEditing(false)}>Cancel</button>
+                        </form>
+                    ) : (
+                        <>
+                            <h1>Welcome back<br />{profile.firstName} {profile.lastName}!</h1>
+                            <button className="edit-button" onClick={() => setEditing(true)}>Edit Name</button>
+                        </>
+                    )}
+                </div>
+                <h2 className="sr-only">Accounts</h2>
+                <section className="account">
+                    <div className="account-content-wrapper">
+                        <h3 className="account-title">Argent Bank Checking (x8349)</h3>
+                        <p className="account-amount">$2,082.79</p>
+                        <p className="account-amount-description">Available Balance</p>
+                    </div>
+                    <div className="account-content-wrapper cta">
+                        <button className="transaction-button">View transactions</button>
+                    </div>
+                </section>
+                <section className="account">
+                    <div className="account-content-wrapper">
+                        <h3 className="account-title">Argent Bank Savings (x6712)</h3>
+                        <p className="account-amount">$10,928.42</p>
+                        <p className="account-amount-description">Available Balance</p>
+                    </div>
+                    <div className="account-content-wrapper cta">
+                        <button className="transaction-button">View transactions</button>
+                    </div>
+                </section>
+                <section className="account">
+                    <div className="account-content-wrapper">
+                        <h3 className="account-title">Argent Bank Credit Card (x8349)</h3>
+                        <p className="account-amount">$184.30</p>
+                        <p className="account-amount-description">Current Balance</p>
+                    </div>
+                    <div className="account-content-wrapper cta">
+                        <button className="transaction-button">View transactions</button>
+                    </div>
+                </section>
+            </main>
+            <Footer />
+        </>
+    );
+}
+
+const ProtectedUserPage = withAuth(UserPage);
+
+export default ProtectedUserPage;
+


### PR DESCRIPTION
## Summary
- add `UserPage` with editable profile information and static account sections
- secure user page with `withAuth` and expose via `/user` route

## Testing
- `npm run lint`
- `npm test` *(fails: jest not found and bcrypt installation error)*

------
https://chatgpt.com/codex/tasks/task_b_68938023d0c48331b2c9bf6ccdefe463