### PR TITLE
feat: add login and profile routes

### DIFF
--- a/frontendClean/src/App.jsx
+++ b/frontendClean/src/App.jsx
@@ -1,11 +1,18 @@
 import { Routes, Route } from 'react-router-dom';
 import HomePage from './components/HomePage.jsx';
 import NotFound from './components/NotFound.jsx';
+import LoginPage from './components/LoginPage.jsx';
+import UserPage from './components/UserPage.jsx';
+import withAuth from './components/withAuth.jsx';
+
+const ProtectedUserPage = withAuth(UserPage);
 
 export default function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/profile" element={<ProtectedUserPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );


### PR DESCRIPTION
## Summary
- add LoginPage and authenticated UserPage routes

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: bcrypt headers 403)*
- `npm --prefix frontendClean run lint`


------
https://chatgpt.com/codex/tasks/task_b_68938024253c83319af2c8120beb09ca